### PR TITLE
updated instruction for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,14 @@ Let's start by adding the bare essentials of an HTML document to the provided
 > inside the `html` tags, if you haven't already.
 
 If written correctly, running `learn test` now will pass three of the seven
-tests. **However** you will not be done yet! We have to make **all** the tests
-pass in order to make the test code happy! Let's get to it!
+tests:
+
+- `has a DOCTYPE tag`
+- `has opening and closing HTML tags`
+- `has <head> and <body> tags nested in the <html> tag`
+
+However you will not be done yet! We have to make **all** the tests pass in
+order to make the test code happy! Let's get to it!
 
 Let's take a closer look at these tags.
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+
+  </head>
+  <body>
+
+  </body>
+</html>


### PR DESCRIPTION
closes #18 

Hi Brigham, thank you for submitting this issue.

I've updated the instruction to note exactly which tests should be passing if you have the DOCTYPE, html, head, and body tags. Here's what that would look like in the `index.html` file:
```html
<!DOCTYPE html>

<html>
  <head>

  </head>
  <body>

  </body>
</html>
```

Thanks again for submitting this issue and helping us improve the curriculum!